### PR TITLE
use `self` instead of `window` to detect browser

### DIFF
--- a/javascript/olm_pre.js
+++ b/javascript/olm_pre.js
@@ -1,9 +1,9 @@
 var get_random_values;
 
-if (typeof(window) !== 'undefined') {
+if (typeof(self) !== 'undefined') {
     // We're in a browser (directly, via browserify, or via webpack).
     get_random_values = function(buf) {
-        window.crypto.getRandomValues(buf);
+        self.crypto.getRandomValues(buf);
     };
 } else if (module["exports"]) {
     // We're running in node.


### PR DESCRIPTION
**Summary**:
This code allows using `olm` from WebWorker context where `window` is not defined.

The current version throws `Error: da.randomBytes is not a function` when running `olmAccount.create()` on the shared worker

[ENG-7189](https://linear.app/comm/issue/ENG-7189/use-self-instead-of-window-to-detect-browser-context).
[ENG-6650#comment-e5fe51c7](https://linear.app/comm/issue/ENG-6650/add-cryptostore-to-shared-worker#comment-e5fe51c7).

**Test plan**
Pre: 
1. In `olm` repo execute `nix build .\#javascript`
2. In all `package.json` files update `@commapp/olm` to be `"@commapp/olm": "file:../../olm/result/javascript"` 
3. Run `yarn cleaninstall`

Node:
1. [Tests](https://github.com/CommE2E/comm/blob/caa001751b1696f8b483906dc43addbce94820f7/keyserver/src/utils/olm-utils.test.js#L7)
2. In `keyserver.js` execute `olmAccount.create()` 

Webapp:
1. Execute `olmAccount.create()`
2. Logout/Login and check if notif session with keyserver was created

Worker:
1. Execute `olmAccount.create()` (tested by @MichalGniadek)

Reviewers:
Would be good if @MichalGniadek and @marcinwasowicz could also review.