### PR TITLE
add method to decrypt only when message order is maintained

### DIFF
--- a/include/olm/error.h
+++ b/include/olm/error.h
@@ -66,6 +66,11 @@ enum OlmErrorCode {
      */
     OLM_PICKLE_EXTRA_DATA = 17,
 
+    /**
+     * One or more messages were skipped and order is not maintained.
+     */
+    OLM_MESSAGE_OUT_OF_ORDER = 18,
+
     /* remember to update the list of string constants in error.c when updating
      * this list. */
 };

--- a/include/olm/olm.h
+++ b/include/olm/olm.h
@@ -539,6 +539,15 @@ OLM_EXPORT size_t olm_decrypt(
     void * plaintext, size_t max_plaintext_length
 );
 
+/** The same as decrypt() but allows decrypting only when messages order
+ * is maintained, otherwise the last_error will be "MESSAGE_OUT_OF_ORDER". */
+OLM_EXPORT size_t olm_decrypt_sequential(
+    OlmSession * session,
+    size_t message_type,
+    void * message, size_t message_length,
+    void * plaintext, size_t max_plaintext_length
+);
+
 /** The length of the buffer needed to hold the SHA-256 hash. */
 OLM_EXPORT size_t olm_sha256_length(
    OlmUtility const * utility

--- a/include/olm/ratchet.hh
+++ b/include/olm/ratchet.hh
@@ -159,10 +159,13 @@ struct OLM_EXPORT Ratchet {
      * BAD_MESSAGE_VERSION if the message was encrypted with an unsupported
      * version of the protocol. The last_error will be BAD_MESSAGE_FORMAT if
      * the message headers could not be decoded. The last_error will be
-     * BAD_MESSAGE_MAC if the message could not be verified */
+     * BAD_MESSAGE_MAC if the message could not be verified. If the
+     * is_sequential parameter is set to true and the order of messages
+     * is not maintained the last_error will be MESSAGE_OUT_OF_ORDER. */
     std::size_t decrypt(
         std::uint8_t const * input, std::size_t input_length,
-        std::uint8_t * plaintext, std::size_t max_plaintext_length
+        std::uint8_t * plaintext, std::size_t max_plaintext_length,
+        bool is_sequential = false
     );
 };
 

--- a/include/olm/session.hh
+++ b/include/olm/session.hh
@@ -134,11 +134,14 @@ struct OLM_EXPORT Session {
      * BAD_MESSAGE_VERSION if the message was encrypted with an unsupported
      * version of the protocol. The last_error will be BAD_MESSAGE_FORMAT if
      * the message headers could not be decoded. The last_error will be
-     * BAD_MESSAGE_MAC if the message could not be verified */
+     * BAD_MESSAGE_MAC if the message could not be verified. If the
+     * is_sequential parameter is set to true and the order of messages
+     * is not maintained the last_error will be MESSAGE_OUT_OF_ORDER. */
     std::size_t decrypt(
         MessageType message_type,
         std::uint8_t const * message, std::size_t message_length,
-        std::uint8_t * plaintext, std::size_t max_plaintext_length
+        std::uint8_t * plaintext, std::size_t max_plaintext_length,
+        bool is_sequential = false
     );
 
     /**

--- a/src/error.c
+++ b/src/error.c
@@ -33,7 +33,8 @@ static const char * ERRORS[] = {
     "BAD_SIGNATURE",
     "OLM_INPUT_BUFFER_TOO_SMALL",
     "OLM_SAS_THEIR_KEY_NOT_SET",
-    "OLM_PICKLE_EXTRA_DATA"
+    "OLM_PICKLE_EXTRA_DATA",
+    "OLM_MESSAGE_OUT_OF_ORDER"
 };
 
 const char * _olm_error_to_string(enum OlmErrorCode error)

--- a/src/olm.cpp
+++ b/src/olm.cpp
@@ -869,7 +869,25 @@ size_t olm_decrypt(
     }
     return from_c(session)->decrypt(
         olm::MessageType(message_type), from_c(message), raw_length,
-        from_c(plaintext), max_plaintext_length
+        from_c(plaintext), max_plaintext_length, false
+    );
+}
+
+size_t olm_decrypt_sequential(
+    OlmSession * session,
+    size_t message_type,
+    void * message, size_t message_length,
+    void * plaintext, size_t max_plaintext_length
+) {
+    std::size_t raw_length = b64_input(
+        from_c(message), message_length, from_c(session)->last_error
+    );
+    if (raw_length == std::size_t(-1)) {
+        return std::size_t(-1);
+    }
+    return from_c(session)->decrypt(
+        olm::MessageType(message_type), from_c(message), raw_length,
+        from_c(plaintext), max_plaintext_length, true
     );
 }
 

--- a/src/ratchet.cpp
+++ b/src/ratchet.cpp
@@ -503,7 +503,8 @@ std::size_t olm::Ratchet::decrypt_max_plaintext_length(
 
 std::size_t olm::Ratchet::decrypt(
     std::uint8_t const * input, std::size_t input_length,
-    std::uint8_t * plaintext, std::size_t max_plaintext_length
+    std::uint8_t * plaintext, std::size_t max_plaintext_length,
+    bool is_sequential
 ) {
     olm::MessageReader reader;
     olm::decode_message(
@@ -554,6 +555,9 @@ std::size_t olm::Ratchet::decrypt(
         result = verify_mac_and_decrypt_for_new_chain(
             *this, reader, plaintext, max_plaintext_length
         );
+    } else if(is_sequential && reader.counter > chain->chain_key.index) {
+        last_error = OlmErrorCode::OLM_MESSAGE_OUT_OF_ORDER;
+        return std::size_t(-1);
     } else if (chain->chain_key.index > reader.counter) {
         /* Chain already advanced beyond the key for this message
          * Check if the message keys are in the skipped key list. */

--- a/src/ratchet.cpp
+++ b/src/ratchet.cpp
@@ -555,7 +555,7 @@ std::size_t olm::Ratchet::decrypt(
         result = verify_mac_and_decrypt_for_new_chain(
             *this, reader, plaintext, max_plaintext_length
         );
-    } else if(is_sequential && reader.counter > chain->chain_key.index) {
+    } else if (is_sequential && reader.counter > chain->chain_key.index) {
         last_error = OlmErrorCode::OLM_MESSAGE_OUT_OF_ORDER;
         return std::size_t(-1);
     } else if (chain->chain_key.index > reader.counter) {

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -395,7 +395,8 @@ std::size_t olm::Session::decrypt_max_plaintext_length(
 std::size_t olm::Session::decrypt(
     olm::MessageType message_type,
     std::uint8_t const * message, std::size_t message_length,
-    std::uint8_t * plaintext, std::size_t max_plaintext_length
+    std::uint8_t * plaintext, std::size_t max_plaintext_length,
+    bool is_sequential
 ) {
     std::uint8_t const * message_body;
     std::size_t message_body_length;
@@ -414,7 +415,8 @@ std::size_t olm::Session::decrypt(
     }
 
     std::size_t result = ratchet.decrypt(
-        message_body, message_body_length, plaintext, max_plaintext_length
+        message_body, message_body_length, plaintext, max_plaintext_length,
+        is_sequential
     );
 
     if (result == std::size_t(-1)) {


### PR DESCRIPTION
Summary:

New API to decrypt messages in sequence, if some messages were skipped `decrypt_sequential` will throw `OLM_MESSAGE_OUT_OF_ORDER`, otherwise should work exactly like the `decrypt()` method.

Test Plan:
Tests, also manually verified the error message (`olm`'s `jest` setup is not capable of checking the exact message).