### PR TITLE
improve error messages while decrypting

### DIFF
--- a/include/olm/error.h
+++ b/include/olm/error.h
@@ -71,6 +71,20 @@ enum OlmErrorCode {
      */
     OLM_MESSAGE_OUT_OF_ORDER = 18,
 
+    /**
+    * This message was already decrypted or the receiver chain advanced
+    * more than MAX_SKIPPED_MESSAGE_KEYS and the key to decrypt
+    * that message was discarded.
+    * If using decrypt() with is_sequential set to true we can assume this error
+    * means that the message was decrypted because in this case, the receiver chain
+    * can advance only by one key while decrypting.
+    */
+    OLM_ALREADY_DECRYPTED_OR_KEYS_SKIPPED = 19,
+
+    OLM_MAX_MESSAGE_GAP_EXCEEDED = 20,
+
+    OLM_SENDER_CHAIN_NOT_ACKNOWLEDGED = 21,
+
     /* remember to update the list of string constants in error.c when updating
      * this list. */
 };

--- a/src/error.c
+++ b/src/error.c
@@ -34,7 +34,10 @@ static const char * ERRORS[] = {
     "OLM_INPUT_BUFFER_TOO_SMALL",
     "OLM_SAS_THEIR_KEY_NOT_SET",
     "OLM_PICKLE_EXTRA_DATA",
-    "OLM_MESSAGE_OUT_OF_ORDER"
+    "OLM_MESSAGE_OUT_OF_ORDER",
+    "OLM_ALREADY_DECRYPTED_OR_KEYS_SKIPPED",
+    "OLM_MAX_MESSAGE_GAP_EXCEEDED",
+    "OLM_SENDER_CHAIN_NOT_ACKNOWLEDGED"
 };
 
 const char * _olm_error_to_string(enum OlmErrorCode error)

--- a/src/ratchet.cpp
+++ b/src/ratchet.cpp
@@ -602,7 +602,7 @@ std::size_t olm::Ratchet::decrypt(
 
     if (result == std::size_t(-1)) {
         /* There was an error but specific error code wasn't set.  */
-        if(last_error == OlmErrorCode::OLM_SUCCESS) {
+        if (last_error == OlmErrorCode::OLM_SUCCESS) {
             last_error = OlmErrorCode::OLM_BAD_MESSAGE_MAC;
         }
         return std::size_t(-1);


### PR DESCRIPTION
**Summary:**
[ENG-7033](https://linear.app/comm/issue/ENG-7033/improve-errors-from-olm).

The most important is the error saying that messages were already decrypted while using `olm_decrypt_sequential` (introduced in https://github.com/CommE2E/olm/pull/11).

Added two more that could potentially help to debug in the future (we had a lot of issues with generic `OLM_BAD_MESSAGE_MAC` related to notifs).

Test Plan:
1. Build `olm` wasm (this executes `olm` repo tests, so decrypting functionality should be unchanged).
2. Patch [D11314](https://phab.comm.dev/D11314).
3. Run `yarn cleaninstall` and execute tests from `olm-utils.test.js`