### PR TITLE
allow initiating X3DH session without OTKs

### DIFF
--- a/include/olm/olm.h
+++ b/include/olm/olm.h
@@ -387,6 +387,22 @@ OLM_EXPORT size_t olm_create_outbound_session(
     void * random, size_t random_length
 );
 
+/** Creates a new out-bound session for sending messages to a given identity_key.
+ * Returns olm_error() on failure. If the keys couldn't be
+ * decoded as base64 then olm_session_last_error() will be "INVALID_BASE64"
+ * If there weren't enough random bytes then olm_session_last_error() will
+ * be "NOT_ENOUGH_RANDOM".
+ * It uses the prekey as one time key to perform three steps of DH. */
+OLM_EXPORT size_t olm_create_outbound_session_without_otk(
+    OlmSession * session,
+    OlmAccount const * account,
+    void const * their_identity_key, size_t their_identity_key_length,
+    void const * their_signing_key, size_t their_signing_key_length,
+    void const * their_pre_key, size_t their_pre_key_length,
+    void const * their_pre_key_signature, size_t their_pre_key_signature_length,
+    void * random, size_t random_length
+);
+
 /** Create a new in-bound session for sending/receiving messages from an
  * incoming PRE_KEY message. Returns olm_error() on failure. If the base64
  * couldn't be decoded then olm_session_last_error will be "INVALID_BASE64".
@@ -394,7 +410,8 @@ OLM_EXPORT size_t olm_create_outbound_session(
  * olm_session_last_error() will be "BAD_MESSAGE_VERSION". If the message
  * couldn't be decoded then olm_session_last_error() will be
  * "BAD_MESSAGE_FORMAT". If the message refers to an unknown one time
- * key then olm_session_last_error() will be "BAD_MESSAGE_KEY_ID". */
+ * key or prekey wasn't used as one time key then
+ * olm_session_last_error() will be "BAD_MESSAGE_KEY_ID". */
 OLM_EXPORT size_t olm_create_inbound_session(
     OlmSession * session,
     OlmAccount * account,
@@ -468,7 +485,8 @@ OLM_EXPORT size_t olm_matches_inbound_session_from(
 
 /** Removes the one time keys that the session used from the account. Returns
  * olm_error() on failure. If the account doesn't have any matching one time
- * keys then olm_account_last_error() will be "BAD_MESSAGE_KEY_ID". */
+ * keys then olm_account_last_error() will be "BAD_MESSAGE_KEY_ID".
+ * If the prekey was used as one time key then this is no-op. */
 OLM_EXPORT size_t olm_remove_one_time_keys(
     OlmAccount * account,
     OlmSession * session

--- a/include/olm/olm.h
+++ b/include/olm/olm.h
@@ -409,9 +409,9 @@ OLM_EXPORT size_t olm_create_outbound_session_without_otk(
  * If the message was for an unsupported protocol version then
  * olm_session_last_error() will be "BAD_MESSAGE_VERSION". If the message
  * couldn't be decoded then olm_session_last_error() will be
- * "BAD_MESSAGE_FORMAT". If the message refers to an unknown one time
- * key or prekey wasn't used as one time key then
- * olm_session_last_error() will be "BAD_MESSAGE_KEY_ID". */
+ * "BAD_MESSAGE_FORMAT". If the message refers to an unknown one time key,
+ * or if the message does not have a one time key and is using an unknown prekey,
+ * then olm_session_last_error() will be "BAD_MESSAGE_KEY_ID". */
 OLM_EXPORT size_t olm_create_inbound_session(
     OlmSession * session,
     OlmAccount * account,
@@ -486,7 +486,7 @@ OLM_EXPORT size_t olm_matches_inbound_session_from(
 /** Removes the one time keys that the session used from the account. Returns
  * olm_error() on failure. If the account doesn't have any matching one time
  * keys then olm_account_last_error() will be "BAD_MESSAGE_KEY_ID".
- * If the prekey was used as one time key then this is no-op. */
+ * If no one time key was used, then this is a no-op. */
 OLM_EXPORT size_t olm_remove_one_time_keys(
     OlmAccount * account,
     OlmSession * session

--- a/include/olm/session.hh
+++ b/include/olm/session.hh
@@ -51,15 +51,16 @@ struct OLM_EXPORT Session {
     /** Start a new outbound session. Returns std::size_t(-1) on failure. Assumes
      * prekey_signature is a byte array of ED25519_SIGNATURE_LENGTH characters. On
      * failure last_error will be set with an error code. The last_error will be
-     * NOT_ENOUGH_RANDOM if the number of random bytes was too small. */
+     * NOT_ENOUGH_RANDOM if the number of random bytes was too small.
+     * When one_time_key is nullptr uses prekey to perform three steps of DH. */
     std::size_t new_outbound_session(
         Account const & local_account,
         _olm_curve25519_public_key const & identity_key,
         _olm_ed25519_public_key const & signing_key,
         _olm_curve25519_public_key const & pre_key,
         std::uint8_t const * prekey_signature,
-        _olm_curve25519_public_key const & one_time_key,
-        std::uint8_t const * random, std::size_t random_length
+        std::uint8_t const * random, std::size_t random_length,
+        _olm_curve25519_public_key const * one_time_key = nullptr
     );
 
     /** Start a new inbound session from a pre-key message.

--- a/javascript/index.d.ts
+++ b/javascript/index.d.ts
@@ -43,7 +43,6 @@ declare class Session {
     create_outbound(
         account: Account, their_identity_key: string, their_one_time_key: string,
     ): void;
-    create_outbound_without_otk(account: Account, their_identity_key: string): void;
     create_inbound(account: Account, one_time_key_message: string): void;
     create_inbound_from(
         account: Account, identity_key: string, one_time_key_message: string,
@@ -57,7 +56,6 @@ declare class Session {
         body: string;
     };
     decrypt(message_type: number, message: string): string;
-    decrypt_sequential(message_type: number, message: string): string;
     describe(): string;
 }
 

--- a/javascript/index.d.ts
+++ b/javascript/index.d.ts
@@ -43,6 +43,7 @@ declare class Session {
     create_outbound(
         account: Account, their_identity_key: string, their_one_time_key: string,
     ): void;
+    create_outbound_without_otk(account: Account, their_identity_key: string): void;
     create_inbound(account: Account, one_time_key_message: string): void;
     create_inbound_from(
         account: Account, identity_key: string, one_time_key_message: string,
@@ -56,6 +57,7 @@ declare class Session {
         body: string;
     };
     decrypt(message_type: number, message: string): string;
+    decrypt_sequential(message_type: number, message: string): string;
     describe(): string;
 }
 

--- a/javascript/olm_post.js
+++ b/javascript/olm_post.js
@@ -413,6 +413,36 @@ Session.prototype['create_outbound'] = restore_stack(function(
     }
 });
 
+Session.prototype['create_outbound_without_otk'] = restore_stack(function(
+    account, their_identity_key, their_signing_key, their_pre_key, their_pre_key_signature
+) {
+    var random_length = session_method(
+        Module['_olm_create_outbound_session_random_length']
+    )(this.ptr);
+    var random = random_stack(random_length);
+    var identity_key_array = array_from_string(their_identity_key);
+    var signing_key_array = array_from_string(their_signing_key);
+    var pre_key_array = array_from_string(their_pre_key);
+    var pre_key_signature_array = array_from_string(their_pre_key_signature);
+    var identity_key_buffer = stack(identity_key_array);
+    var signing_key_buffer = stack(signing_key_array);
+    var pre_key_buffer = stack(pre_key_array);
+    var pre_key_signature_buffer = stack(pre_key_signature_array);
+    try {
+        session_method(Module['_olm_create_outbound_session_without_otk'])(
+            this.ptr, account.ptr,
+            identity_key_buffer, identity_key_array.length,
+            signing_key_buffer, signing_key_array.length,
+            pre_key_buffer, pre_key_array.length,
+            pre_key_signature_buffer, pre_key_signature_array.length,
+            random, random_length
+        );
+    } finally {
+        // clear the random buffer, which is key data
+        bzero(random, random_length);
+    }
+});
+
 Session.prototype['create_inbound'] = restore_stack(function(
     account, one_time_key_message
 ) {

--- a/javascript/test/olm.spec.js
+++ b/javascript/test/olm.spec.js
@@ -40,6 +40,15 @@ describe("olm", function() {
             aliceSession = new Olm.Session();
             bobSession = new Olm.Session();
 
+            aliceAccount.create();
+            bobAccount.create();
+
+            bobAccount.generate_prekey();
+            bobAccount.mark_prekey_as_published();
+            bobAccount.generate_prekey();
+            bobAccount.mark_prekey_as_published();
+            bobAccount.forget_old_prekey();
+
             done();
         });
     });
@@ -66,32 +75,20 @@ describe("olm", function() {
         }
     });
 
-    it('should encrypt and decrypt', function() {
-        aliceAccount.create();
-        bobAccount.create();
+    function testPickleAndRestore(){
+        var alicePickleKey = 'SomeSecretAlice';
+        var bobPickleKey = 'SomeSecretBob';
+        var aliceSessionPickled = aliceSession.pickle(alicePickleKey);
+        var bobSessionPickled = bobSession.pickle(bobPickleKey);
 
-        bobAccount.generate_one_time_keys(1);
-        var bobOneTimeKeys = JSON.parse(bobAccount.one_time_keys()).curve25519;
-        bobAccount.mark_keys_as_published();
+        aliceSession = new Olm.Session();
+        bobSession = new Olm.Session();
 
-        var bobIdKey = JSON.parse(bobAccount.identity_keys()).curve25519;
-        var bobSigningKey = JSON.parse(bobAccount.identity_keys()).ed25519;
+        aliceSession.unpickle(alicePickleKey, aliceSessionPickled);
+        bobSession.unpickle(bobPickleKey, bobSessionPickled);
+    }
 
-        bobAccount.generate_prekey();
-        bobAccount.mark_prekey_as_published();
-        bobAccount.generate_prekey();
-        bobAccount.mark_prekey_as_published();
-        bobAccount.forget_old_prekey();
-
-        var bobPrekey = Object.values(JSON.parse(bobAccount.prekey()).curve25519)[0];
-        var bobPreKeySignature = bobAccount.prekey_signature();
-
-        var otk_id = Object.keys(bobOneTimeKeys)[0];
-
-        aliceSession.create_outbound(
-            aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature, bobOneTimeKeys[otk_id]
-        );
-
+    function testEncryptDecrypt() {
         var TEST_TEXT='têst1';
         var encrypted = aliceSession.encrypt(TEST_TEXT);
         expect(encrypted.type).toEqual(0);
@@ -108,17 +105,7 @@ describe("olm", function() {
         console.log(TEST_TEXT, "->", decrypted);
         expect(decrypted).toEqual(TEST_TEXT);
 
-        // Pickle and restore sessions
-        var alicePickleKey = 'SomeSecretAlice';
-        var bobPickleKey = 'SomeSecretBob';
-        var aliceSessionPickled = aliceSession.pickle(alicePickleKey);
-        var bobSessionPickled = bobSession.pickle(bobPickleKey);
-
-        aliceSession = new Olm.Session();
-        bobSession = new Olm.Session();
-
-        aliceSession.unpickle(alicePickleKey, aliceSessionPickled);
-        bobSession.unpickle(bobPickleKey, bobSessionPickled);
+        testPickleAndRestore();
 
         TEST_TEXT='some emoji: ☕ 123 // after pickling';
         encrypted = bobSession.encrypt(TEST_TEXT);
@@ -126,34 +113,9 @@ describe("olm", function() {
         decrypted = aliceSession.decrypt(encrypted.type, encrypted.body);
         console.log(TEST_TEXT, "->", decrypted);
         expect(decrypted).toEqual(TEST_TEXT);
-    });
+    }
 
-    it('should encrypt and decrypt sequential', function() {
-        aliceAccount.create();
-        bobAccount.create();
-
-        bobAccount.generate_one_time_keys(1);
-        var bobOneTimeKeys = JSON.parse(bobAccount.one_time_keys()).curve25519;
-        bobAccount.mark_keys_as_published();
-
-        var bobIdKey = JSON.parse(bobAccount.identity_keys()).curve25519;
-        var bobSigningKey = JSON.parse(bobAccount.identity_keys()).ed25519;
-
-        bobAccount.generate_prekey();
-        bobAccount.mark_prekey_as_published();
-        bobAccount.generate_prekey();
-        bobAccount.mark_prekey_as_published();
-        bobAccount.forget_old_prekey();
-
-        var bobPrekey = Object.values(JSON.parse(bobAccount.prekey()).curve25519)[0];
-        var bobPreKeySignature = bobAccount.prekey_signature();
-
-        var otk_id = Object.keys(bobOneTimeKeys)[0];
-
-        aliceSession.create_outbound(
-            aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature, bobOneTimeKeys[otk_id]
-        );
-
+    function testEncryptDecryptSequential() {
         var TEST_TEXT='têst1';
         var encrypted = aliceSession.encrypt(TEST_TEXT);
         expect(encrypted.type).toEqual(0);
@@ -170,6 +132,7 @@ describe("olm", function() {
         console.log(TEST_TEXT, "->", decrypted);
         expect(decrypted).toEqual(TEST_TEXT);
 
+        testPickleAndRestore();
 
         var TEST_TEXT_1 ='some emoji: ☕ 123';
         var encrypted_1 = bobSession.encrypt(TEST_TEXT_1);
@@ -190,5 +153,74 @@ describe("olm", function() {
         var decrypted2 = aliceSession.decrypt(encrypted_2.type, encrypted_2.body);
         console.log(TEST_TEXT_2, "->", decrypted2);
         expect(decrypted2).toEqual(TEST_TEXT_2);
+    }
+
+    it('should encrypt and decrypt with session created with OTK', function() {
+        bobAccount.generate_one_time_keys(1);
+        var bobOneTimeKeys = JSON.parse(bobAccount.one_time_keys()).curve25519;
+        bobAccount.mark_keys_as_published();
+
+        var bobIdKey = JSON.parse(bobAccount.identity_keys()).curve25519;
+        var bobSigningKey = JSON.parse(bobAccount.identity_keys()).ed25519;
+
+        var bobPrekey = Object.values(JSON.parse(bobAccount.prekey()).curve25519)[0];
+        var bobPreKeySignature = bobAccount.prekey_signature();
+
+        var otk_id = Object.keys(bobOneTimeKeys)[0];
+
+        aliceSession.create_outbound(
+            aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature, bobOneTimeKeys[otk_id]
+        );
+
+        testEncryptDecrypt()
     });
+
+    it('should encrypt and decrypt sequential with session created with OTK', function() {
+        bobAccount.generate_one_time_keys(1);
+        var bobOneTimeKeys = JSON.parse(bobAccount.one_time_keys()).curve25519;
+        bobAccount.mark_keys_as_published();
+
+        var bobIdKey = JSON.parse(bobAccount.identity_keys()).curve25519;
+        var bobSigningKey = JSON.parse(bobAccount.identity_keys()).ed25519;
+
+        var bobPrekey = Object.values(JSON.parse(bobAccount.prekey()).curve25519)[0];
+        var bobPreKeySignature = bobAccount.prekey_signature();
+
+        var otk_id = Object.keys(bobOneTimeKeys)[0];
+
+        aliceSession.create_outbound(
+            aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature, bobOneTimeKeys[otk_id]
+        );
+
+        testEncryptDecryptSequential();
+    });
+
+    it('should encrypt and decrypt with session created without OTK', function() {
+        var bobIdKey = JSON.parse(bobAccount.identity_keys()).curve25519;
+        var bobSigningKey = JSON.parse(bobAccount.identity_keys()).ed25519;
+
+        var bobPrekey = Object.values(JSON.parse(bobAccount.prekey()).curve25519)[0];
+        var bobPreKeySignature = bobAccount.prekey_signature();
+
+        aliceSession.create_outbound_without_otk(
+            aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature
+        );
+
+        testEncryptDecrypt()
+    });
+
+    it('should encrypt and decrypt sequential with session created without OTK', function() {
+        var bobIdKey = JSON.parse(bobAccount.identity_keys()).curve25519;
+        var bobSigningKey = JSON.parse(bobAccount.identity_keys()).ed25519;
+
+        var bobPrekey = Object.values(JSON.parse(bobAccount.prekey()).curve25519)[0];
+        var bobPreKeySignature = bobAccount.prekey_signature();
+
+        aliceSession.create_outbound_without_otk(
+            aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature
+        );
+
+        testEncryptDecryptSequential()
+    });
+
 });

--- a/javascript/test/olm.spec.js
+++ b/javascript/test/olm.spec.js
@@ -172,7 +172,7 @@ describe("olm", function() {
             aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature, bobOneTimeKeys[otk_id]
         );
 
-        testEncryptDecrypt()
+        testEncryptDecrypt();
     });
 
     it('should encrypt and decrypt sequential with session created with OTK', function() {
@@ -206,7 +206,7 @@ describe("olm", function() {
             aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature
         );
 
-        testEncryptDecrypt()
+        testEncryptDecrypt();
     });
 
     it('should encrypt and decrypt sequential with session created without OTK', function() {
@@ -220,7 +220,6 @@ describe("olm", function() {
             aliceAccount, bobIdKey, bobSigningKey, bobPrekey, bobPreKeySignature
         );
 
-        testEncryptDecryptSequential()
+        testEncryptDecryptSequential();
     });
-
 });

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -60,8 +60,8 @@ std::size_t olm::Session::new_outbound_session(
     _olm_ed25519_public_key const & signing_key,
     _olm_curve25519_public_key const & pre_key,
     std::uint8_t const * pre_key_signature,
-    _olm_curve25519_public_key const & one_time_key,
-    std::uint8_t const * random, std::size_t random_length
+    std::uint8_t const * random, std::size_t random_length,
+    _olm_curve25519_public_key const * one_time_key
 ) {
     if (random_length < new_outbound_session_random_length()) {
         last_error = OlmErrorCode::OLM_NOT_ENOUGH_RANDOM;
@@ -81,7 +81,13 @@ std::size_t olm::Session::new_outbound_session(
     received_message = false;
     alice_identity_key = alice_identity_key_pair.public_key;
     alice_base_key = base_key.public_key;
-    bob_one_time_key = one_time_key;
+
+    if (one_time_key) {
+        bob_one_time_key = *one_time_key;
+    } else {
+        bob_one_time_key = pre_key;
+    }
+
     bob_prekey = pre_key;
 
     // Verify prekey signature
@@ -94,11 +100,11 @@ std::size_t olm::Session::new_outbound_session(
     std::uint8_t secret[4 * CURVE25519_SHARED_SECRET_LENGTH];
     std::uint8_t * pos = secret;
 
-    _olm_crypto_curve25519_shared_secret(&alice_identity_key_pair, &one_time_key, pos);
+    _olm_crypto_curve25519_shared_secret(&alice_identity_key_pair, &bob_one_time_key, pos);
     pos += CURVE25519_SHARED_SECRET_LENGTH;
     _olm_crypto_curve25519_shared_secret(&base_key, &identity_key, pos);
     pos += CURVE25519_SHARED_SECRET_LENGTH;
-    _olm_crypto_curve25519_shared_secret(&base_key, &one_time_key, pos);
+    _olm_crypto_curve25519_shared_secret(&base_key, &bob_one_time_key, pos );
     pos += CURVE25519_SHARED_SECRET_LENGTH;
     _olm_crypto_curve25519_shared_secret(&base_key, &pre_key, pos);
 
@@ -179,7 +185,12 @@ std::size_t olm::Session::new_inbound_session(
         bob_one_time_key
     );
 
-    if (!our_one_time_key) {
+    bool using_prekey_as_otk = olm::array_equal(
+        bob_prekey.public_key,
+        bob_one_time_key.public_key
+    );
+
+    if (!our_one_time_key && !using_prekey_as_otk) {
         last_error = OlmErrorCode::OLM_BAD_MESSAGE_KEY_ID;
         return std::size_t(-1);
     }
@@ -196,7 +207,8 @@ std::size_t olm::Session::new_inbound_session(
     _olm_curve25519_key_pair const & bob_identity_key = (
         local_account.identity_keys.curve25519_key
     );
-    _olm_curve25519_key_pair const & bob_one_time_key = our_one_time_key->key;
+    _olm_curve25519_key_pair const & bob_one_time_key =
+        using_prekey_as_otk ? our_prekey->key : our_one_time_key->key;
     _olm_curve25519_key_pair const & bob_prekey = our_prekey->key;
 
     // Calculate the shared secret S via triple DH

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -97,8 +97,9 @@ std::size_t olm::Session::new_outbound_session(
     }
 
     // Calculate the shared secret S via triple DH
-    std::uint8_t secret[CURVE25519_SHARED_SECRET_LENGTH * 4];
+    std::uint8_t secret[4 * CURVE25519_SHARED_SECRET_LENGTH];
     std::uint8_t * pos = secret;
+
     _olm_crypto_curve25519_shared_secret(&alice_identity_key_pair, &bob_one_time_key, pos);
     pos += CURVE25519_SHARED_SECRET_LENGTH;
     _olm_crypto_curve25519_shared_secret(&base_key, &identity_key, pos);
@@ -215,7 +216,7 @@ std::size_t olm::Session::new_inbound_session(
     _olm_curve25519_key_pair const & bob_prekey = our_prekey->key;
 
     // Calculate the shared secret S via triple DH
-    std::uint8_t secret[4 * CURVE25519_SHARED_SECRET_LENGTH];
+    std::uint8_t secret[CURVE25519_SHARED_SECRET_LENGTH * 4];
     std::uint8_t * pos = secret;
     _olm_crypto_curve25519_shared_secret(&bob_one_time_key, &alice_identity_key, pos);
     pos += CURVE25519_SHARED_SECRET_LENGTH;


### PR DESCRIPTION
Context in: [ENG-7659](https://linear.app/comm/issue/ENG-7659/update-olm-fork-to-allow-initiating-x3dh-session-without-otks).

Singal spec: [link](https://signal.org/docs/specifications/x3dh/).

**Couple of notes:**
1. `olm.h` is a C-style file and does not support optional parameters so introducing a new function with a meaningful name, not overloading the existing one because otherwise, WASM compilation gets more complicated.
2. There is a code duplication between `olm_create_outbound_session_without_otk` and `olm_create_outbound_session` but not sure if refactoring this wouldn't break the convention in this file.
3. The order of params in `new_outbound_session` had to be changed because non-optional params couldn't follow optional params.
4.  Refactored the testing code to avoid duplication.

**Backward compatibility:**
C1 - new client with `olm` version after this PR is merged
C2 - older client with current `olm` version

1. With OTKs 
Because of having OTKs both C1 should make 4 steps of DH and C2 always make 4 steps so this should work for all cases (no matter which client is inbound/outbound).

2. Without OTKs
a. C1 is outbound and C2 is inbound - in that case, C1 will create a session with 3 steps but C2 will still make 4 steps of DH so session creation will fail with `OLM_BAD_MESSAGE_KEY_ID`.
b. C1 is inbound and C2 is outbound - C2 is not able to create a session without OTKs so we do not get to the point when C1 receives any request.


**Alternatives:**
This solution uses prekey as a one-time key so effectively prekey is serialized twice, and deciding if a session was created with OTKs is done by comparing if the prekey and one-time key are equal.
We could update this to change the format of serialized messages to include explicit information about prekey or one-time usage but this will require a lot more change across the entire `olm` and make it harder to maintain backward compatibility.

**Testing:**
1. encrypt/decrypt with OTKs
2. encrypt/decrypt without OTKs
3. encrypt/decryptSequential with OTKs
4. encrypt/decryptSequential without OTKs
5. Tested partially backward compatibility by printing pickled accounts and keys on two different `olm` version but planning to do more detailed testing on actual clients after this PR is merged (but before bumping version in `comm` codebase)