### PR TITLE
Expose Session::ratchet::sender_chain::empty() to JS

### DIFF
--- a/include/olm/olm.h
+++ b/include/olm/olm.h
@@ -445,6 +445,10 @@ OLM_EXPORT int olm_session_has_received_message(
     OlmSession const *session
 );
 
+OLM_EXPORT int olm_session_is_sender_chain_empty(
+    OlmSession const *session
+);
+
 /**
  * Write a null-terminated string describing the internal state of an olm
  * session to the buffer provided for debugging and logging purposes. If the

--- a/javascript/olm_post.js
+++ b/javascript/olm_post.js
@@ -498,6 +498,11 @@ Session.prototype['has_received_message'] = function() {
     ) ? true : false;
 };
 
+Session.prototype['is_sender_chain_empty'] = function() {
+    return session_method(Module['_olm_session_is_sender_chain_empty'])(
+        this.ptr
+    ) ? true : false;
+};
 
 Session.prototype['matches_inbound'] = restore_stack(function(
     one_time_key_message

--- a/src/olm.cpp
+++ b/src/olm.cpp
@@ -766,6 +766,12 @@ int olm_session_has_received_message(
     return from_c(session)->received_message;
 }
 
+int olm_session_is_sender_chain_empty(
+    OlmSession const * session
+) {
+    return from_c(session)->ratchet.sender_chain.empty();
+}
+
 void olm_session_describe(
     OlmSession * session, char *buf, size_t buflen
 ) {


### PR DESCRIPTION
Context in [ENG-8477](https://linear.app/comm/issue/ENG-8477/handle-race-condition-when-two-clients-initiate-notifs-sessions)

**Quick overview**

The intention of this work is to expose `Session::ratchet::sender_chain::empty()` property to JS bindings so that it can be utilised to handle notification session initialisation race condition on web platforms.

**Testing**
1. Initialise Alice session as outbound. Ensure sender chain of Alice session is not empty and `has_received_message` flag is unset.
2. Encrypt message using Alice session.
3. Initialise Bob session as inbound using encrypted message from step 2. Ensure that sender chain of bob session is empty and `has_received_message` flag is set.
4. Encrypt message using Bob session. Ensure that sender chain of bob session is not empty.
5. Decrypt message encrypted in step 4 using Alice session. Ensure that `has_received_message` flag is set for Alice session.

