### PR TITLE
implement functions to get total and used memory

### DIFF
--- a/include/olm/olm.h
+++ b/include/olm/olm.h
@@ -594,6 +594,12 @@ OLM_EXPORT size_t olm_ed25519_verify(
     void * signature, size_t signature_length
 );
 
+/** Function to get the total memory allocated to the Emscripten heap in bytes.  */
+OLM_EXPORT unsigned int olm_get_total_memory(void);
+
+/** Function to calculate and return the amount of free memory available in bytes. */
+OLM_EXPORT unsigned int olm_get_free_memory(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/olm/olm.h
+++ b/include/olm/olm.h
@@ -597,8 +597,8 @@ OLM_EXPORT size_t olm_ed25519_verify(
 /** Function to get the total memory allocated to the Emscripten heap in bytes.  */
 OLM_EXPORT unsigned int olm_get_total_memory(void);
 
-/** Function to calculate and return the amount of free memory available in bytes. */
-OLM_EXPORT unsigned int olm_get_free_memory(void);
+/** Function to calculate and return the amount of used memory in bytes. */
+OLM_EXPORT int olm_get_used_memory(void);
 
 #ifdef __cplusplus
 }

--- a/javascript/olm_post.js
+++ b/javascript/olm_post.js
@@ -784,6 +784,6 @@ olm_exports["get_total_memory"] = restore_stack(function() {
     return Module['_olm_get_total_memory']();
 });
 
-olm_exports["get_free_memory"] = restore_stack(function() {
-    return Module['_olm_get_free_memory']();
+olm_exports["get_used_memory"] = restore_stack(function() {
+    return Module['_olm_get_used_memory']();
 });

--- a/javascript/olm_post.js
+++ b/javascript/olm_post.js
@@ -779,3 +779,11 @@ olm_exports["get_library_version"] = restore_stack(function() {
         getValue(buf+2, 'i8'),
     ];
 });
+
+olm_exports["get_total_memory"] = restore_stack(function() {
+    return Module['_olm_get_total_memory']();
+});
+
+olm_exports["get_free_memory"] = restore_stack(function() {
+    return Module['_olm_get_free_memory']();
+});

--- a/javascript/test/memory.spec.js
+++ b/javascript/test/memory.spec.js
@@ -9,19 +9,37 @@ describe("olm memory", function() {
         });
     });
 
-    it('should return memory size', function() {
+    it('should return memory size and allocate more memory if needed', function() {
         // Total memory was set in Makefile
         const configured_total_memory = 262144; //256 * 1024
         expect(Olm.get_total_memory()).toEqual(configured_total_memory);
 
+        // One `Account` object requires 7816 bytes of memory.
+        // To test re-allocating memory, more than 262144 bytes are needed,
+        // to achieve that create ~40 Accounts.
         const memory_before_creation = Olm.get_used_memory();
-        var account = new Olm.Account();
-        account.create();
+
+        let accounts = [];
+        for(let it = 0; it < 40; it = it + 1) {
+            const account = new Olm.Account();
+            account.create();
+            accounts.push(account);
+        }
+
         const memory_after_creation = Olm.get_used_memory();
         expect(memory_after_creation).toBeGreaterThan(memory_before_creation);
 
-        account.free();
+        expect(Olm.get_total_memory()).toBeGreaterThan(configured_total_memory);
+
+        for(let it = 0; it < 40; it = it + 1) {
+            accounts[it].free();
+        }
+
         const memory_after_freeing = Olm.get_used_memory();
+        // The entire allocated memory was released.
         expect(memory_after_freeing).toEqual(memory_before_creation);
+
+        // Not checking if total memory shrinks,
+        // because this is not supported by Emscripten.
     });
 });

--- a/javascript/test/memory.spec.js
+++ b/javascript/test/memory.spec.js
@@ -3,10 +3,8 @@
 var Olm = require('../olm');
 
 describe("olm memory", function() {
-    beforeEach(function(done) {
-        Olm.init().then(function() {
-            done();
-        });
+    beforeEach(async function() {
+        await Olm.init();
     });
 
     it('should return memory size and allocate more memory if needed', function() {

--- a/javascript/test/memory.spec.js
+++ b/javascript/test/memory.spec.js
@@ -20,7 +20,7 @@ describe("olm memory", function() {
         const memory_before_creation = Olm.get_used_memory();
 
         let accounts = [];
-        for(let it = 0; it < 40; it = it + 1) {
+        for (let it = 0; it < 40; it = it + 1) {
             const account = new Olm.Account();
             account.create();
             accounts.push(account);
@@ -31,7 +31,7 @@ describe("olm memory", function() {
 
         expect(Olm.get_total_memory()).toBeGreaterThan(configured_total_memory);
 
-        for(let it = 0; it < 40; it = it + 1) {
+        for (let it = 0; it < 40; it = it + 1) {
             accounts[it].free();
         }
 

--- a/javascript/test/memory.spec.js
+++ b/javascript/test/memory.spec.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 OpenMarket Ltd
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+"use strict";
+
+var Olm = require('../olm');
+
+if (!Object.keys) {
+    Object.keys = function(o) {
+        var k=[], p;
+        for (p in o) if (Object.prototype.hasOwnProperty.call(o,p)) k.push(p);
+        return k;
+    }
+}
+
+describe("olm memory", function() {
+    beforeEach(function(done) {
+        Olm.init().then(function() {
+            done();
+        });
+    });
+
+    it('should return memory size', function() {
+        // Total memory was set in Makefile
+        const configured_total_memory = 262144; //256 * 1024
+        expect(Olm.get_total_memory()).toEqual(configured_total_memory);
+
+        const memory_before_creation = Olm.get_free_memory();
+        var account = new Olm.Account();
+        account.create();
+        const memory_after_creation = Olm.get_free_memory();
+        expect(memory_after_creation).toBeLessThan(memory_before_creation);
+
+        account.free();
+        const memory_after_freeing = Olm.get_free_memory();
+        expect(memory_after_freeing).toEqual(memory_before_creation);
+    });
+});

--- a/javascript/test/memory.spec.js
+++ b/javascript/test/memory.spec.js
@@ -39,14 +39,14 @@ describe("olm memory", function() {
         const configured_total_memory = 262144; //256 * 1024
         expect(Olm.get_total_memory()).toEqual(configured_total_memory);
 
-        const memory_before_creation = Olm.get_free_memory();
+        const memory_before_creation = Olm.get_used_memory();
         var account = new Olm.Account();
         account.create();
-        const memory_after_creation = Olm.get_free_memory();
-        expect(memory_after_creation).toBeLessThan(memory_before_creation);
+        const memory_after_creation = Olm.get_used_memory();
+        expect(memory_after_creation).toBeGreaterThan(memory_before_creation);
 
         account.free();
-        const memory_after_freeing = Olm.get_free_memory();
+        const memory_after_freeing = Olm.get_used_memory();
         expect(memory_after_freeing).toEqual(memory_before_creation);
     });
 });

--- a/javascript/test/memory.spec.js
+++ b/javascript/test/memory.spec.js
@@ -1,31 +1,6 @@
-/*
-Copyright 2016 OpenMarket Ltd
-Copyright 2018 New Vector Ltd
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 "use strict";
 
 var Olm = require('../olm');
-
-if (!Object.keys) {
-    Object.keys = function(o) {
-        var k=[], p;
-        for (p in o) if (Object.prototype.hasOwnProperty.call(o,p)) k.push(p);
-        return k;
-    }
-}
 
 describe("olm memory", function() {
     beforeEach(function(done) {

--- a/src/olm.cpp
+++ b/src/olm.cpp
@@ -1033,13 +1033,12 @@ unsigned int olm_get_total_memory() {
     return total_memory;
 }
 
-unsigned int olm_get_free_memory() {
+int olm_get_used_memory() {
     s_mallinfo info = mallinfo();
-    int totalMemory = EM_ASM_INT(return HEAP8.length);
     unsigned int dynamicTop = reinterpret_cast<unsigned int>(sbrk(0));
-    unsigned int free_memory = totalMemory - dynamicTop + info.fordblks;
-    std::cout << "Free memory: " << free_memory << " bytes" << std::endl;
-    return free_memory;
+    int used_memory = dynamicTop - info.fordblks ;
+    std::cout << "Used memory: " << used_memory << " bytes\n";
+    return used_memory;
 }
 
 }

--- a/src/olm.cpp
+++ b/src/olm.cpp
@@ -1037,7 +1037,7 @@ int olm_get_used_memory() {
     s_mallinfo info = mallinfo();
     unsigned int dynamicTop = reinterpret_cast<unsigned int>(sbrk(0));
     int used_memory = dynamicTop - info.fordblks ;
-    std::cout << "Used memory: " << used_memory << " bytes\n";
+    std::cout << "Used memory: " << used_memory << " bytes" << std::endl;
     return used_memory;
 }
 


### PR DESCRIPTION
**Summary** 

This should help us debug memory usage by the Olm module. We have some issues and we suspect this might be connected to exceeding memory limits, with this changes we can explore total and used memory by Olm.

I also added additional logging at the C++ level, this is to avoid the need to configure webpack/babel to print logs on prod (Emscripten logs are printed regardless of deployment type).

We want to call this API in some time intervals to get some metrics on how memory usage changes over time.

This was inspired by code in Emscripten codebase ([link](https://github.com/emscripten-core/emscripten/blob/9bb322f8a7ee89d6ac67e828b9c7a7022ddf8de2/tests/mallinfo.cpp)).

**Test plan**
See added tests