### PR TITLE
fix Emscripten-specific functions

### DIFF
--- a/include/olm/olm.h
+++ b/include/olm/olm.h
@@ -594,11 +594,14 @@ OLM_EXPORT size_t olm_ed25519_verify(
     void * signature, size_t signature_length
 );
 
+/** The block below contains only Emscripten-specific functions. */
+#ifdef EMSCRIPTEN
 /** Function to get the total memory allocated to the Emscripten heap in bytes.  */
 OLM_EXPORT unsigned int olm_get_total_memory(void);
 
 /** Function to calculate and return the amount of used memory in bytes. */
 OLM_EXPORT int olm_get_used_memory(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/olm.cpp
+++ b/src/olm.cpp
@@ -23,7 +23,6 @@
 
 #ifdef EMSCRIPTEN
 #include <emscripten/emscripten.h>
-#include <iostream>
 #include <unistd.h>
 #endif
 
@@ -1031,17 +1030,13 @@ extern "C" {
 }
 
 unsigned int olm_get_total_memory() {
-    unsigned int total_memory = EM_ASM_INT(return HEAP8.length);
-    std::cout << "Total memory: " << total_memory << " bytes" << std::endl;
-    return total_memory;
+    return EM_ASM_INT(return HEAP8.length);
 }
 
 int olm_get_used_memory() {
     s_mallinfo info = mallinfo();
     unsigned int dynamicTop = reinterpret_cast<unsigned int>(sbrk(0));
-    int used_memory = dynamicTop - info.fordblks ;
-    std::cout << "Used memory: " << used_memory << " bytes" << std::endl;
-    return used_memory;
+    return dynamicTop - info.fordblks ;
 }
 #endif
 

--- a/src/olm.cpp
+++ b/src/olm.cpp
@@ -21,12 +21,14 @@
 #include "olm/base64.hh"
 #include "olm/memory.hh"
 
+#ifdef EMSCRIPTEN
 #include <emscripten/emscripten.h>
+#include <iostream>
+#include <unistd.h>
+#endif
 
 #include <new>
 #include <cstring>
-#include <iostream>
-#include <unistd.h>
 
 namespace {
 
@@ -1009,6 +1011,7 @@ size_t olm_ed25519_verify(
     );
 }
 
+#ifdef EMSCRIPTEN
 extern "C" {
     struct s_mallinfo {
         int arena;    /* non-mmapped space allocated from system */
@@ -1040,5 +1043,6 @@ int olm_get_used_memory() {
     std::cout << "Used memory: " << used_memory << " bytes" << std::endl;
     return used_memory;
 }
+#endif
 
 }


### PR DESCRIPTION
**Summary**
This is a fix for https://github.com/CommE2E/olm/pull/15. We ended up adding `#include <emscripten/emscripten.h>` config, which isn't great because we use Olm directly (as a repo) in our mobile app native code. 

Fixing this using directives, which are commonly used in Olm and in our Comm codebase.

There is also one more improvement, after doing some more testing I think adding logging on the C++ side was a bad idea, it is not really convenient (spam and hard to debug), I am going to try a different approach and log **only** when we detect any differences, e.g.:
```
let olmTotalMemory = 0;
function verifyMemoryUsage(method: string) {
  try {
    const currentTotalMemory = olm.get_total_memory();
    if (currentTotalMemory !== olmTotalMemory) {
      console.error(
        `Olm's total memory grows from ${olmTotalMemory} ` +
          `to ${currentTotalMemory} after executing ${method} method`,
      ); // This is fine because we don't remove `console.error` on prod
      olmTotalMemory = currentTotalMemory;
    }
  } catch (e) {
    console.error('Encountered error while trying log Olm memory', e);
  }
}
```

**Test Plan**
1. Tests.
2. Build Comm mobile app after linking Olm with changes from this PR
3. Make sure there are no logging on web/keyserver